### PR TITLE
travis: Run i386 and amd64 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ dist: trusty
 language: c
 sudo: true
 script: test/travis-run
+env:
+ - ARCH=amd64
+ - ARCH=i386

--- a/test/travis-run
+++ b/test/travis-run
@@ -27,10 +27,10 @@ apt-get install -y dh-autoreconf pkg-config libvirt-dev libsystemd-dev libtool p
 # run build and tests as user
 chown -R buildd:buildd /build
 su - buildd <<EOU
+set -ex
 cd /build/src
 ./autogen.sh
 make -j4
 make check || { cat test-suite.log; exit 1; }
 EOU
 EOF
-

--- a/test/travis-run
+++ b/test/travis-run
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
-RELEASE=${1:-zesty}
-ARCH=${2:-amd64}
+echo ${RELEASE:=zesty}
+echo ${ARCH:=amd64}
 
 # get LP chroot
 CHROOT_URL=$(curl --silent https://api.launchpad.net/1.0/ubuntu/$RELEASE/$ARCH | grep -o 'http://[^ "]*chroot-ubuntu-[^ "]*')


### PR DESCRIPTION
This should help to catch errors on 32 bit platforms.

Also, add a second commit to run test build/check under set -e