### PR TITLE
travis: Add build for Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ script: test/travis-run
 env:
  - ARCH=amd64
  - ARCH=i386
+ - RELEASE=xenial


### PR DESCRIPTION
This already has sd-bus, but an older libvirt (1.3.1 instead of 2.5 in
zesty), it's useful to test against older APIs too.